### PR TITLE
Increase request body size limit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Logs
+.vscode
 logs
 *.log
 npm-debug.log*

--- a/src/server.js
+++ b/src/server.js
@@ -4,7 +4,10 @@ const process = require('process')
 const app = express()
 const port = 3000
 
-app.use(express.json());
+app.use(express.json({
+    // default is 100kb
+    limit: "1000kb",
+}));
 
 app.get('/', (req, res) => {
   res.json({status: 'ok'})


### PR DESCRIPTION
[ENG-1691 : Fix requests too large issue with Snowflake proxy](https://linear.app/varos/issue/ENG-1691/fix-requests-too-large-issue-with-snowflake-proxy)

I noticed that sometimes insight query requests fail because the query template gets too large for big competitive sets